### PR TITLE
fix(docker): permission denied in nodered image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
 FROM nodered/node-red
 
+## As /data is usually going to be used to provide the node-red flows, we change the cache
+## to another directory, since when mounting /data the cache will be lost
+USER root
+
+RUN mkdir -p /npm_cache && \
+  chown node-red:node-red /npm_cache && \
+  npm config set cache /npm_cache --global
+
+USER node-red
+
 RUN npm install --save @alvarobc2412/status@latest
 
 COPY settings.js /data/settings.js

--- a/setup.bat
+++ b/setup.bat
@@ -8,6 +8,9 @@ copy .env.deploy status-backend\.env
 
 copy .env.deploy .env
 
+:: If a folder is not created before doing a bind mount in Docker, the folder will be created with root permissions only.
+md node-red-status >nul 2>&1
+
 docker compose -p status up -d
 
 echo "Configuración completada. Visita http://localhost:3000 para ver la aplicación o http://localhost:3001/docs para acceder a la documentación de la API."

--- a/setup.sh
+++ b/setup.sh
@@ -8,6 +8,9 @@ cp .env.deploy ./status-backend/.env
 
 cp .env.deploy .env
 
+## If a folder is not created before doing a bind mount in Docker, the folder will be created with root permissions only.
+mkdir -p node-red-status
+
 docker compose -p status up -d 
 
 echo "Setup completado. Accede a http://localhost:3000 para ver la aplicación o a http://localhost:3001/docs para acceder a la documentación de la API."


### PR DESCRIPTION
* If a folder is not created before doing a bind mount in Docker, the folder will be created with root permissions only. node-red container runs as node-red user, so it can't access it. **In order for this to work, the node-red-status folder must be brand new**. For instance, if node-red is already running, stopping the container and running ``./setup.sh`` won't fix it, the ``node-red-status`` folder must be deleted and recreated by the user or the script previous Docker mounts int.
* Change node_modules cache directory to another place outside /data, so it doesn't conflict when mounting the /data directory during status install.