### PR TITLE
fix: missing networks in non-emulated compose, assets manager permissions

### DIFF
--- a/docker-compose-emulated.yml
+++ b/docker-compose-emulated.yml
@@ -75,6 +75,8 @@ services:
     platform: linux/amd64
     container_name: bluejay-assets-manager
     image: "governify/assets-manager:develop"
+    # Needed so the volume can be written by the container after creation
+    user: root
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
@@ -304,6 +306,7 @@ services:
       MYSQL_ALLOW_EMPTY_PASSWORD: yes
     healthcheck:
       test: mysqladmin ping -h localhost
+      start_period: 10s
       retries: 10
     ports:
       - "3306:3306"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,8 @@ services:
     ports:
       - "1880:1880"
     volumes:
-      - ./settings.js:/data/settings.js
       - ./node-red-status:/data
+      - ./settings.js:/data/settings.js
     command: node-red
     networks:
       - web_network
@@ -73,6 +73,8 @@ services:
   bluejay-assets-manager:
     container_name: bluejay-assets-manager
     image: "governify/assets-manager:develop"
+    # Needed so the volume can be written by the container after creation
+    user: root
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
@@ -93,11 +95,11 @@ services:
   # ================================================
   bluejay-reporter:
     container_name: bluejay-reporter
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     build:
       context: ./reporter
       dockerfile: Dockerfile
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - NODE_ENV=production
       - PORT=80
@@ -135,11 +137,11 @@ services:
   # ================================================
   bluejay-collector-events:
     container_name: bluejay-collector-events
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     build:
       context: ./collector-events
       dockerfile: Dockerfile
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     env_file:
       - .env
     environment:
@@ -160,6 +162,8 @@ services:
       - bluejay-redis-ec
     mem_limit: 700m
     restart: "unless-stopped"
+    networks:
+      - web_network
   # ================================================
   bluejay-dashboard:
     container_name: bluejay-dashboard


### PR DESCRIPTION
* The web_network was missing from the collector in non emulated setups
* When the volume is created by Docker daemon on first run, it's created as root, so the container has a permission denied. There's 2 ways to solve this:
    * Create the folder before spinning up the compose
    * Set the container's to root, albeit the increase in the surface of potential attacks.

In a discussion with @alvarobernal2412, we decided it's better to take option 2, since it's more maintainable to keep all the volume handling with Docker and not mess with it manually because we're probably going to change where the mountpoints of the container are located at some point (and that would require editing the script as well). The increase of the surface of attack is negligible in our use case. 